### PR TITLE
refactor: apply optimizations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,3 @@
-declare const formattedOsNames: Record<string, string>;
-declare const sizes: string[];
-declare const base: number;
-
-declare function formatBytes(bytes: number): string;
-
 interface SystemRequirements {
   os: string;
   processor: string;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import { osInfo, cpu, mem, graphics, fsSize } from 'systeminformation';
 
 const formattedOsNames = {
@@ -11,7 +13,7 @@ const formattedOsNames = {
     android: 'Android'
   },
   sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-  base = 1024;
+  logBase = Math.log(1024);
 
 /**
  * Formats bytes into a more readable string.
@@ -19,12 +21,9 @@ const formattedOsNames = {
  * @returns {string} The formatted bytes.
  */
 function formatBytes(bytes) {
-  if (typeof bytes !== 'number' || isNaN(bytes))
-    throw new TypeError("Argument 'bytes' must be a number.");
+  const exponent = Math.floor(Math.log(bytes) / logBase);
 
-  const exponent = Math.floor(Math.log(bytes) / Math.log(base));
-
-  return `${(bytes / Math.pow(base, exponent)).toFixed()} ${sizes[exponent]}`;
+  return `${(bytes / Math.pow(1024, exponent)).toFixed()} ${sizes[exponent]}`;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,10 +8,20 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
+  "keywords": [
+    "steam", "version"
+  ],
   "author": "Mohammed Keyvanzadeh <mohammadkeyvanzade94@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "systeminformation": "^5.11.9"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/VoltrexMaster/steam-sysreq/issues"
+  },
+  "homepage": "https://github.com/VoltrexMaster/steam-sysreq",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VoltrexMaster/steam-sysreq"
+  },
 }


### PR DESCRIPTION
changelog in this patch:
- change license "ISC" to "MIT" in package.json
- add GitHub repository URL to package.json
- remove private functions and variables from being exported in index.d.ts
- replaced `Math.log(1024)` with the result, as it will always be constant `6.931471805599453`
- removed checks in `formatBytes`, as it will only be used privately with the parameter being the variables returned from a third-party library (which should *always* be a `number`)